### PR TITLE
Handle flags properly (AO-14073)

### DIFF
--- a/v2/internal/pluginrpc/collect_service.go
+++ b/v2/internal/pluginrpc/collect_service.go
@@ -90,7 +90,7 @@ func (cs *collectService) Info(ctx context.Context, request *InfoRequest) (*Info
 
 	select {
 	case statistics := <-cs.statsController.RequestStat():
-		if statistics.IsEmpty() {
+		if statistics == nil {
 			return response, fmt.Errorf("can't gather statistics (statistics server is not running): %v", err)
 		}
 

--- a/v2/internal/pluginrpc/conversion.go
+++ b/v2/internal/pluginrpc/conversion.go
@@ -150,7 +150,7 @@ func fromGRPCValue(v *MetricValue) (interface{}, error) {
 	return nil, fmt.Errorf("unknown type of metric value: %T", v.DataVariant)
 }
 
-func toGRPCInfo(statistics stats.Statistics, pprofLocation string) (*Info, error) {
+func toGRPCInfo(statistics *stats.Statistics, pprofLocation string) (*Info, error) {
 	pi := &statistics.PluginInfo
 	ts := &statistics.TasksSummary
 

--- a/v2/internal/plugins/collector/stats/statistics.go
+++ b/v2/internal/plugins/collector/stats/statistics.go
@@ -9,12 +9,6 @@ type Statistics struct {
 	PluginInfo   pluginInfo             `json:"Plugin info"`
 	TasksSummary tasksSummary           `json:"Tasks summary"`
 	TasksDetails map[string]taskDetails `json:"Task details"`
-
-	isFilled bool
-}
-
-func (s Statistics) IsEmpty() bool {
-	return !s.isFilled
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
https://swicloud.atlassian.net/browse/AO-14073

Summary of changes:
* Log level
* Info() returns error when stats server is not running,
* Info() doesn't panic when pprof is not enabled

Notes:
* tested with snap-mock and example-collector
