### PR TITLE
Data race in plugin-lib-go (AO-16844)

### DIFF
--- a/v2/internal/plugins/common/proxy/context.go
+++ b/v2/internal/plugins/common/proxy/context.go
@@ -196,17 +196,14 @@ func (c *Context) AttachContext(parentCtx context.Context) {
 	c.ctxMu.Lock()
 	defer c.ctxMu.Unlock()
 
-	if c.ctx == nil {
-		c.ctx, c.cancelFn = context.WithCancel(parentCtx)
-	}
+	c.ctx, c.cancelFn = context.WithCancel(parentCtx)
 }
 
 func (c *Context) ReleaseContext() {
 	c.ctxMu.Lock()
 	defer c.ctxMu.Unlock()
 
-	if c.ctx != nil {
+	if c.cancelFn != nil {
 		c.cancelFn()
-		c.ctx = nil
 	}
 }


### PR DESCRIPTION
Data race in plugin-lib-go (AO-16844)

* Fixed data race during acquired and released plugin context by protect it by mutex

JIRA: (AO-16844)