### PR TITLE
Lib does not print out the stats server address (AO-17216)

### DIFF
--- a/v2/runner/addons.go
+++ b/v2/runner/addons.go
@@ -68,7 +68,7 @@ func startPprofServer(ctx context.Context, ln net.Listener) {
 
 func startStatsServer(ctx context.Context, ln net.Listener, stats stats.Controller) {
 	logF := log.WithCtx(ctx).WithFields(moduleFields)
-	logF.Infof("Running stats server on address")
+	logF.Infof("Running stats server on address %s", ln.Addr())
 
 	h := http.NewServeMux()
 


### PR DESCRIPTION
Lib does not print out the stats server address (AO-17216)

* Added log for printing out the stats server address

JIRA: (AO-17216)